### PR TITLE
Add clang-format to cmake image

### DIFF
--- a/cmake/Dockerfile
+++ b/cmake/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update --fix-missing \
     make \
     build-essential \
     libssl-dev \
+    clang-format \
     clang-tidy \
     iwyu \
     cppcheck \


### PR DESCRIPTION
This way we can run clang-tidy in circle-ci